### PR TITLE
Publish: Use new workfiles API to increment current workfile

### DIFF
--- a/client/ayon_motionbuilder/plugins/publish/increment_workfile_version.py
+++ b/client/ayon_motionbuilder/plugins/publish/increment_workfile_version.py
@@ -1,4 +1,7 @@
+import os
+
 import pyblish.api
+
 from ayon_core.lib import version_up
 from ayon_core.pipeline import registered_host
 
@@ -14,5 +17,31 @@ class IncrementWorkfileVersion(pyblish.api.ContextPlugin):
     def process(self, context):
         host = registered_host()
         path = context.data["currentFile"]
-        self.log.info(f"Increment and save workfile: {path}")
-        host.save_workfile(version_up(path))
+        try:
+            from ayon_core.pipeline.workfile import save_next_version
+            from ayon_core.host.interfaces import SaveWorkfileOptionalData
+
+            current_filename = os.path.basename(path)
+            save_next_version(
+                description=(
+                    f"Incremented by publishing from {current_filename}"
+                ),
+                # Optimize the save by reducing needed queries for context
+                prepared_data=SaveWorkfileOptionalData(
+                    project_entity=context.data["projectEntity"],
+                    project_settings=context.data["project_settings"],
+                    anatomy=context.data["anatomy"],
+                )
+            )
+            new_path = host.get_current_workfile()
+
+        except ImportError:
+            # Backwards compatibility before ayon-core 1.5.0
+            self.log.debug(
+                "Using legacy `version_up`. Update AYON core addon to "
+                "use newer `save_next_version` function."
+            )
+            new_path = version_up(path)
+            host.save_workfile(new_path)
+
+        self.log.info(f"Increment and save workfile: {new_path}")


### PR DESCRIPTION
## Changelog Description

When incrementing the workfile during publish, use the new context-based workfile API so that the current author information is stored with the saved file.

## Additional review information

Test with ayon-core 1.5.0 (and also backwards compatibility against older releases)

## Testing notes:

1. Publishing should work
2. Workfile should be incremented
3. Workfile should show the author of the publish 
4. Workfile should have 'artist note' set: "Incremented by publishing."
5. Publishing should also still work and increment (the old way) with older ayon-core.
